### PR TITLE
Add Neo Tunnel Flutter example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ app.*.symbols
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 !/dev/ci/**/Gemfile.lock
+/flutter/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # tunnel-demo
-a visual app that drawing neo tunnel repeatly
+
+This repository contains a simple Flutter example that renders an animated
+"neo tunnel" effect.
+
+The Flutter source code resides in `neo_tunnel/`. To build for Android, iOS,
+macOS, or Windows, navigate into that directory and run `flutter create .`
+followed by `flutter run` for your target platform.

--- a/neo_tunnel/README.md
+++ b/neo_tunnel/README.md
@@ -1,0 +1,7 @@
+# Neo Tunnel
+
+A simple cross-platform Flutter app that shows an animated "neo tunnel" effect.
+
+This project includes only the Dart source and `pubspec.yaml`. To build for a
+specific platform (Android, iOS, macOS, or Windows), run `flutter create .` in
+this directory to generate the platform folders, then use `flutter run`.

--- a/neo_tunnel/lib/main.dart
+++ b/neo_tunnel/lib/main.dart
@@ -1,0 +1,94 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+void main() => runApp(const NeoTunnelApp());
+
+class NeoTunnelApp extends StatelessWidget {
+  const NeoTunnelApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Neo Tunnel',
+      theme: ThemeData.dark(),
+      home: const TunnelPage(),
+      debugShowCheckedModeBanner: false,
+    );
+  }
+}
+
+class TunnelPage extends StatefulWidget {
+  const TunnelPage({super.key});
+
+  @override
+  State<TunnelPage> createState() => _TunnelPageState();
+}
+
+class _TunnelPageState extends State<TunnelPage>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 20),
+    )..repeat();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: AnimatedBuilder(
+        animation: _controller,
+        builder: (context, child) {
+          return CustomPaint(
+            painter: _TunnelPainter(depth: _controller.value * 60),
+            child: Container(),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _TunnelPainter extends CustomPainter {
+  _TunnelPainter({required this.depth});
+
+  final double depth;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = size.center(Offset.zero);
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2
+      ..color = Colors.cyanAccent;
+
+    const int lines = 40;
+    const double spacing = 20;
+
+    for (int i = 0; i < lines; i++) {
+      final double d = (i - depth) * spacing;
+      final double scale = math.pow(1.05, d).toDouble();
+      final rect = Rect.fromCenter(
+        center: center,
+        width: size.width / scale,
+        height: size.height / scale,
+      );
+      canvas.drawRect(rect, paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _TunnelPainter oldDelegate) =>
+      oldDelegate.depth != depth;
+}

--- a/neo_tunnel/pubspec.yaml
+++ b/neo_tunnel/pubspec.yaml
@@ -1,0 +1,17 @@
+name: neo_tunnel
+version: 0.1.0
+publish_to: none
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add a Flutter example under `neo_tunnel` that draws a neon-like tunnel effect
- update README with instructions
- ignore local Flutter SDK directory

## Testing
- `dart format neo_tunnel/lib/main.dart`
- ❌ `flutter analyze neo_tunnel` *(failed: network restrictions for downloading fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6856011a9d608322aa315023b590467b